### PR TITLE
update tentacat dependency

### DIFF
--- a/mix.lock
+++ b/mix.lock
@@ -11,4 +11,4 @@
   "mimerl": {:hex, :mimerl, "1.0.2"},
   "mock": {:hex, :mock, "0.1.1"},
   "ssl_verify_hostname": {:hex, :ssl_verify_hostname, "1.0.5"},
-  "tentacat": {:git, "https://github.com/duksis/tentacat.git", "2fce1c0ab3d034f4df2c55529a6191e1f25368d8", [branch: "user_events"]}}
+  "tentacat": {:git, "https://github.com/edgurgel/tentacat.git", "223d306f79134202175f8013222178d825494887", []}}


### PR DESCRIPTION
Prior to this commit gute_taten was pinned to a sha of Tentacat that did
not support paging through a user's repositories and events. This commit
bumps that dependency version so that *all* repos are examined and *all*
user events from at most 90 days or 300 events (as limited by the
GitHub API) are examined.

Close #1
Close #2