### PR TITLE
Limit the amount of v2 deeds we care about (again!)

### DIFF
--- a/lib/gute_taten.ex
+++ b/lib/gute_taten.ex
@@ -9,8 +9,27 @@ defmodule GuteTaten do
   @default_rules ["UsefulProjects", "GivingBackTheLove"]
   @rules Application.get_env(:gute_taten, :rules, @default_rules)
 
-  @spec retrieve(binary, [binary]) :: [map]
-  def retrieve(username, rules \\ @rules) do
-    Stream.flat_map(rules, fn(x) -> Module.concat(__MODULE__, x).call(username) end)
+  @spec retrieve(binary) :: binary
+  def retrieve(github_identity) do
+    github_identity
+      |> search_deeds
+      |> format_output
+  end
+
+  @spec search_deeds(binary, [binary]) :: [map]
+  defp search_deeds(github_username, rules \\ @rules) do
+    Enum.map(rules, fn(x) -> Module.concat(__MODULE__, x).call(github_username) end)
+      |> List.flatten
+  end
+
+  @spec format_output([map]) :: binary
+  defp format_output(response) do
+    #TODO implement cofigurable output formaters csv, json ...
+    response |> to_json
+  end
+
+  @spec to_json([map]) :: binary
+  defp to_json(deeds) do
+    deeds |> JSX.encode! |> JSX.prettify!
   end
 end

--- a/lib/gute_taten/giving_back_the_love.ex
+++ b/lib/gute_taten/giving_back_the_love.ex
@@ -1,13 +1,13 @@
 defmodule GuteTaten.GivingBackTheLove do
 
-  def call(github_username, _api \\ GuteTaten.Api) do
+  def call(github_username, api \\ GuteTaten.Api) do
     # api.call([:Tentacat, :Users, :Events], :list_public, [github_username])
-    list_public_events(github_username, client)
-    |> Stream.filter(&pull_request_event/1)
-    |> Stream.filter(&open_pr/1)
-    |> Stream.filter(&exclude_user(&1, github_username))
-    |> Stream.filter(&has_been_merged/1)
-    |> Stream.map(fn(x) -> %{ name: "Is contributing back", reference: html_url(x), description: description(x), stars: stars(x)} end)
+    Tentacat.Users.Events.list_public(github_username, client)
+    |> Enum.filter(&pull_request_event/1)
+    |> Enum.filter(&open_pr/1)
+    |> Enum.filter(&exclude_user(&1, github_username))
+    |> Enum.filter(&has_been_merged/1)
+    |> Enum.map(fn(x) -> %{ name: "Is contributing back", reference: html_url(x), description: description(x), stars: stars(x)} end)
   end
 
   defp has_been_merged(%{"merged_at" => nil}), do: false
@@ -33,10 +33,6 @@ defmodule GuteTaten.GivingBackTheLove do
       %{"payload" => %{"pull_request" => %{"html_url" =>  <<^path::binary-size(path_size)>> <> _}}} -> false
       _ -> true
     end
-  end
-
-  defp list_public_events(github_username, client) do
-    Tentacat.get("users/#{github_username}/events/public", client, [], [pagination: :stream])
   end
 
   defp client do

--- a/lib/gute_taten/giving_back_the_love_v2.ex
+++ b/lib/gute_taten/giving_back_the_love_v2.ex
@@ -3,13 +3,13 @@ defmodule GuteTaten.GivingBackTheLoveV2 do
   alias Githubarchive.Event
   alias Githubarchive.Repo
 
-  def call(github_username, _api \\ GuteTaten.Api) do
+  def call(github_username, api \\ GuteTaten.Api) do
     pull_request_open_events(github_username)
     |> Stream.filter(&exclude_user(&1, github_username))
     |> Stream.map(&event_to_pr/1)
     |> Stream.filter(&has_been_merged/1)
     |> Stream.map(fn(x) -> %{ name: "Is contributing back", reference: Map.fetch!(x, "html_url"), description: description(x), stars: stars(x)} end)
-    |> Stream.take(2)
+    |> Enum.take(2)
   end
 
   defp pull_request_open_events(user) do

--- a/lib/gute_taten/useful_projects.ex
+++ b/lib/gute_taten/useful_projects.ex
@@ -1,10 +1,10 @@
 defmodule GuteTaten.UsefulProjects do
   def call(github_username) do
     github_username
-    |> user_public_repos(client)
-    |> Stream.filter(fn(x) -> Map.fetch!(x, "fork") == false end)
-    |> Stream.filter(fn(x) -> Map.fetch!(x, "stargazers_count") >= 5 end)
-    |> Stream.map(fn(x) -> %{ name: "Useful project", reference: Map.fetch!(x, "html_url"), description: Map.fetch!(x, "description"), stars: Map.fetch!(x, "stargazers_count")} end)
+    |> Tentacat.Repositories.list_users(client)
+    |> Enum.filter(fn(x) -> Map.fetch!(x, "fork") == false end)
+    |> Enum.filter(fn(x) -> Map.fetch!(x, "stargazers_count") >= 5 end)
+    |> Enum.map(fn(x) -> %{ name: "Useful project", reference: Map.fetch!(x, "html_url"), description: Map.fetch!(x, "description"), stars: Map.fetch!(x, "stargazers_count")} end)
   end
 
   defp client do
@@ -12,9 +12,5 @@ defmodule GuteTaten.UsefulProjects do
       nil -> %Tentacat.Client{}
       token -> Tentacat.Client.new(%{access_token: token})
     end
-  end
-
-  defp user_public_repos(owner, client) do
-    Tentacat.get "users/#{owner}/repos", client, [], [pagination: :stream]
   end
 end

--- a/lib/mix/tasks/taten.ex
+++ b/lib/mix/tasks/taten.ex
@@ -21,15 +21,11 @@ defmodule Mix.Tasks.Taten do
     |> Enum.each(&Application.ensure_all_started/1)
     Tentacat.start
     Githubarchive.Repo.start_link
-    arg |> GuteTaten.retrieve |> Enum.map(&print/1)
+    arg |> GuteTaten.retrieve |> IO.puts
   end
   def run(_), do: run([])
 
   defp usage do
     IO.puts @moduledoc
-  end
-
-  defp print(deed) do
-    JSX.encode!(deed) |> JSX.prettify! |> IO.puts
   end
 end

--- a/test/gute_taten_test.exs
+++ b/test/gute_taten_test.exs
@@ -29,11 +29,7 @@ defmodule GuteTatenTest do
       ]\
       """
 
-      assert Enum.to_list(GuteTaten.retrieve("RoxasShadow")) == JSX.decode!(json_output) |> Enum.map(&atomize_keys/1)
+      assert GuteTaten.retrieve("RoxasShadow") == json_output
     end
-  end
-
-  defp atomize_keys(string_key_map) do
-    for {key, val} <- string_key_map, into: %{}, do: {String.to_atom(key), val}
   end
 end


### PR DESCRIPTION
Since this spawns a bunch of HTTP requests, for a very active GitHub user it will
actually time out leading them to fail the GD check.

This reverts the undeployed refactor from the master branch.